### PR TITLE
Add vscode-cpp-essentials.sh script

### DIFF
--- a/vscode-cpp-essentials.sh
+++ b/vscode-cpp-essentials.sh
@@ -14,7 +14,7 @@ if [ -z "$(which code)" ]; then
   echo -e "\033[0mYou can install using snap with the following command:\n"
 
 
-  echo -e "\x1B[01;93m   $ apt install --classic code\n"
+  echo -e "\x1B[01;93m   $ apt install code\n"
 
 
 else

--- a/vscode-cpp-essentials.sh
+++ b/vscode-cpp-essentials.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+
+
+
+
+
+if [ -z "$(which code)" ]; then
+
+
+  echo -e "\x1B[31m[ERROR] This script requires Visual Studio Code installed.\n"
+
+
+  echo -e "\033[0mYou can install using snap with the following command:\n"
+
+
+  echo -e "\x1B[01;93m   $ snap install --classic code\n"
+
+
+else
+
+
+  code --install-extension xaver.clang-format --force
+
+
+  code --install-extension ms-vscode.cpptools --force
+
+
+  code --install-extension ms-vscode.cpptools-extension-pack --force
+
+
+  code --install-extension llvm-vs-code-extensions.vscode-clangd --force
+
+
+  code --install-extension streetsidesoftware.code-spell-checker --force
+
+
+  code --install-extension eamodio.gitlens --force
+
+
+  code --install-extension wayou.vscode-todo-highlight --force
+
+
+  code --install-extension cschlosser.doxdocgen --force
+
+
+  code --install-extension akiramiyakoda.cppincludeguard --force
+
+
+  code --install-extension tdennis4496.cmantic --force
+
+
+  code --install-extension tonka3000.qtvsctools --force
+
+
+  code --install-extension zxh404.vscode-proto3 --force
+
+
+  # todo: new class template
+
+
+  # todo: static check
+
+
+fi

--- a/vscode-cpp-essentials.sh
+++ b/vscode-cpp-essentials.sh
@@ -14,7 +14,7 @@ if [ -z "$(which code)" ]; then
   echo -e "\033[0mYou can install using snap with the following command:\n"
 
 
-  echo -e "\x1B[01;93m   $ snap install --classic code\n"
+  echo -e "\x1B[01;93m   $ apt install --classic code\n"
 
 
 else

--- a/vscode-cpp-essentials.sh
+++ b/vscode-cpp-essentials.sh
@@ -35,9 +35,6 @@ else
   code --install-extension streetsidesoftware.code-spell-checker --force
 
 
-  code --install-extension eamodio.gitlens --force
-
-
   code --install-extension wayou.vscode-todo-highlight --force
 
 


### PR DESCRIPTION
Adds back the Visual Studio Code extensions installation script to set up a C++ environment.