### PR TITLE
Remove --break-system-packages flag from aqtinstall installation just for Ubuntu 22.04 compatibility

### DIFF
--- a/qt.sh
+++ b/qt.sh
@@ -55,7 +55,13 @@ apt install 'libxcb*-dev' \
             libxrender-dev \
             libxi-dev -y
 
-pip3 install aqtinstall
+UBUNTU_VERSION=$(lsb_release -rs)
+
+if dpkg --compare-versions "$UBUNTU_VERSION" ge "24.04"; then
+  pip3 install aqtinstall --break-system-packages
+else
+  pip3 install aqtinstall
+fi
 
 rm -rf "${TMP_WORK_DIR}"
 mkdir -p "${TMP_WORK_DIR}"

--- a/qt.sh
+++ b/qt.sh
@@ -55,7 +55,7 @@ apt install 'libxcb*-dev' \
             libxrender-dev \
             libxi-dev -y
 
-pip3 install aqtinstall --break-system-packages
+pip3 install aqtinstall
 
 rm -rf "${TMP_WORK_DIR}"
 mkdir -p "${TMP_WORK_DIR}"


### PR DESCRIPTION
## :memo: Summary
This PR removes the `--break-system-packages` flag from the `pip3 install aqtinstall` command in the Qt installation script for Ubuntu 22.04.

While the flag is supported and functions correctly on newer versions of `pip3` (e.g., Ubuntu 24.04), it leads to failure on Ubuntu 22.04 due to stricter protections against modifying system-managed Python environments. By removing the flag, we ensure smoother compatibility with Ubuntu 22.04 without relying on pip internals or requiring manual intervention.

## :dart: Changes made

This PR removes the `--break-system-packages` argument from the following line in the Qt installation script if Ubuntu version is 22.04:

```bash
pip3 install aqtinstall --break-system-packages
```

Now becomes:

```bash
UBUNTU_VERSION=$(lsb_release -rs)

if dpkg --compare-versions "$UBUNTU_VERSION" ge "24.04"; then
  pip3 install aqtinstall --break-system-packages
else
  pip3 install aqtinstall
fi
```

## :question: Why This Change Was Made

- The `--break-system-packages` flag is commonly used on Debian-based systems (e.g., Ubuntu 22.04+) to bypass certain package management protections in Python. While useful, it can lead to system instability or package conflicts. On Ubuntu 24.04, this flag is needed to bypass the `externally-managed-environment` error when installing `aqtinstall` via `pip3`.
- For Ubuntu 22.04, removing this flag enhances compatibility and promotes safer package management, particularly in environments that depend on system-level Python packages.

## :rocket: Impact

- No change in the script's core functionality.
- Increases portability and ensures greater compatibility across multiple Ubuntu versions.

## ✅ How to test?
- Follow the standard instructions to install all dependencies for either the VSS or SSL projects, using this branch of `scripts-ubuntu-common`.
- Perform the installation on both Ubuntu 22.04 and 24.04 environments to verify compatibility and behavior.

:bulb: **Tip!** You can quickly validate the script by:
- Running it inside a Docker container based on each Ubuntu version, or
- Triggering the project's GitHub Actions to verify that everything builds correctly in CI.