### PR TITLE
Add rcpilot dependency scripts.

### DIFF
--- a/eigen.sh
+++ b/eigen.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+function is_root {
+  [ "${EUID:-$(id -u)}" -eq 0 ];
+}
+
+if ! is_root; then
+  echo -e "\x1B[31m[ERROR] This script requires root privileges."
+  exit 1
+fi
+
+function install_release {
+    tar -xf $ARCHIVE_NAME
+    cd $EXTRACTED_DIR
+    mkdir -p build
+    cd build
+    cmake ..
+    make install
+    cd ..
+}
+
+EIGEN_VERSION="3.4.1"
+SOURCE_URL="https://gitlab.com/libeigen/eigen/-/archive/${EIGEN_VERSION}/eigen-${EIGEN_VERSION}.tar.bz2"
+ARCHIVE_NAME="eigen-${EIGEN_VERSION}.tar.gz"
+EXTRACTED_DIR="eigen-${EIGEN_VERSION}"
+TMP_DIR="/tmp/eigen"
+
+rm -rf "${TMP_DIR}"
+mkdir -p "${TMP_DIR}"
+
+echo -e "\x1B[01;93mDownloading Eigen ${EIGEN_VERSION}...\n\u001b[0m"
+
+curl -L $SOURCE_URL -o $ARCHIVE_NAME
+
+echo -e "\x1B[01;93m\Extracting and installing...\n\u001b[0m"
+
+pushd "${TMP_DIR}" || exit 1
+install_release
+popd || exit 1
+rm -rf $ARCHIVE_NAME $EXTRACTED_DIR

--- a/ros2-dependencies.sh
+++ b/ros2-dependencies.sh
@@ -15,4 +15,4 @@ if [ -z "$ROS_DISTRO" ]; then
 fi
 
 # Messages
-apt install ros-$ROS_DISTRO-geographic-msgs
+apt install ros-$ROS_DISTRO-geographic-msgs -y

--- a/ros2-dependencies.sh
+++ b/ros2-dependencies.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function is_root {
+  [ "${EUID:-$(id -u)}" -eq 0 ];
+}
+
+if ! is_root; then
+  echo -e "\x1B[31m[ERROR] This script requires root privileges."
+  exit 1
+fi
+
+if [ -z "$ROS_DISTRO" ]; then
+  echo -e "\x1B[31m[ERROR] No ROS distros found."
+  exit 1
+fi
+
+# Messages
+apt install ros-$ROS_DISTRO-geographic-msgs


### PR DESCRIPTION
This pull request adds two new shell scripts to automate environment setup tasks. The first script, `eigen.sh`, installs the Eigen C++ library, while the second script, `ros2-dependencies.sh`, installs a required ROS 2 dependency. Both scripts include checks to ensure they are run with root privileges for proper installation.

**New installation scripts:**

* Added `eigen.sh` to automate downloading, extracting, building, and installing the Eigen 3.4.1 library, including root privilege checks and temporary directory management.
* Added `ros2-dependencies.sh` to install the `geographic-msgs` ROS 2 package for the current ROS distribution, with checks for root privileges and valid ROS distribution environment variable.